### PR TITLE
fix: install wget and ssh

### DIFF
--- a/brew_v2
+++ b/brew_v2
@@ -81,6 +81,7 @@ virt-sysprep -a $PATHV2 \
 		--run-command 'echo "chmod +x /root/install_packets_for_v2.sh /root/install_v2_projects.sh" >> /root/get_v2all' \
 		--run-command 'echo "/root/install_packets_for_v2.sh && /root/install_v2_projects.sh" >> /root/get_v2all' \
 		--run-command 'chmod +x /root/get_v2all' \
+		--run-command 'apt install --yes wget ssh' \
 		--run-command 'cd /root; wget https://raw.githubusercontent.com/virtualsquare/virtualsquare.github.io/master/archive/install_scripts/append_to.bashrc' \
 		--run-command 'cd /etc/profile.d; wget https://raw.githubusercontent.com/virtualsquare/virtualsquare.github.io/master/archive/install_scripts/local_lib.sh' \
 		--run-command 'ssh-keygen -A' \


### PR DESCRIPTION
I've noticed that the VM image provided to use virtualsquare tools is broken. In fact if we run the script the image is partially generated with some error.

To fix this errors we need to install wget and ssh (to make ssh-keygen work).